### PR TITLE
Adding missing Ubuntu docker images

### DIFF
--- a/types/RunsOn.dhall
+++ b/types/RunsOn.dhall
@@ -1,6 +1,9 @@
 < windows-latest
 | windows-2019
 | ubuntu-latest
+| `ubuntu-20.10`
+| `ubuntu-20.04`
+| `ubuntu-19.10`
 | `ubuntu-18.04`
 | `ubuntu-16.04`
 | macos-latest


### PR DESCRIPTION
As defined at https://hub.docker.com/_/ubuntu/