### PR TITLE
Simplifying usage of sbt-ci-release

### DIFF
--- a/examples/release-scala.dhall
+++ b/examples/release-scala.dhall
@@ -1,17 +1,11 @@
 let GithubActions =
-      ../package.dhall sha256:70379601fc41305d287544ff1b368e44e3ac0d8b601f0e15afa36b651a8ffe07
+      ../package.dhall sha256:40602cb9f4e3d1964e87bc88385c7946d9796b0fb1358249fce439ac9f30c726
 
 let setup =
       [ GithubActions.steps.checkout
       , GithubActions.steps.olafurpg/java-setup { java-version = "11" }
       , GithubActions.steps.olafurpg/gpg-setup
       , GithubActions.steps.olafurpg/sbt-ci-release
-          { ref = "\${{ github.ref }}"
-          , pgpPassphrase = "\${{ secrets.PGP_PASSPHRASE }}"
-          , pgpSecret = "\${{ secrets.PGP_SECRET }}"
-          , sonatypePassword = "\${{ secrets.SONATYPE_PASSWORD }}"
-          , sonatypeUsername = "\${{ secrets.SONATYPE_USERNAME }}"
-          }
       ]
 
 in  GithubActions.Workflow::{

--- a/package.dhall
+++ b/package.dhall
@@ -1,6 +1,6 @@
   ./schemas.dhall sha256:0a2890df03db778d6f372a5ee52c4e958f6d85299f44e3be6226c6560441156d
 ∧ { steps =
-      ./steps.dhall sha256:e40bea26bb37689fbb50304fcf861c7c719bfc9d9bd3cfb0a1ea2d362138d05e
+      ./steps.dhall sha256:017656f6c6604ad58e48d558ba926265e637ac503e1d438e06b698f6a10aa372
   }
 ∧ { types =
       ./types.dhall sha256:82cab623b825528392f725220f6eb424ff85c6efe668435445d5aa111d184b53

--- a/steps.dhall
+++ b/steps.dhall
@@ -23,5 +23,5 @@
 , olafurpg/gpg-setup =
     ./steps/olafurpg/gpg-setup.dhall sha256:d58e53f881fcd63053ac902fe97e842b56c00576adf93007c2a8a6370bb843f0
 , olafurpg/sbt-ci-release =
-    ./steps/olafurpg/sbt-ci-release.dhall sha256:e1a6e31166b6ced82265a1880991b3b5de55f8c325bc03da0e547f2abc7ef72b
+    ./steps/olafurpg/sbt-ci-release.dhall sha256:28b676449303888dbb028ad960e587004e761c0afa283cf4d5bce0d4eafb2288
 }

--- a/steps/olafurpg/gpg-setup.dhall
+++ b/steps/olafurpg/gpg-setup.dhall
@@ -1,6 +1,6 @@
 let Step = ../../schemas/Step.dhall
 
-in Step::{
+in  Step::{
     , id = None Text
     , name = None Text
     , uses = Some "olafurpg/setup-gpg@v2"

--- a/steps/olafurpg/sbt-ci-release.dhall
+++ b/steps/olafurpg/sbt-ci-release.dhall
@@ -1,17 +1,16 @@
 let Step = ../../schemas/Step.dhall
 
-in    λ(args : { ref : Text, pgpPassphrase: Text, pgpSecret: Text, sonatypePassword: Text, sonatypeUsername: Text })
-    → Step::{
-      , id = None Text
-      , name = Some "Publish ${args.ref}"
-      , uses = None Text
-      , run = Some "sbt ci-release"
-      , env = Some
-          ( toMap
-              { PGP_PASSPHRASE = args.pgpPassphrase
-              , PGP_SECRET = args.pgpSecret
-              , SONATYPE_PASSWORD = args.sonatypePassword
-              , SONATYPE_USERNAME = args.sonatypeUsername
-              }
-          )
-      }
+in  Step::{
+    , id = None Text
+    , name = Some "Publish \${{ github.ref }}"
+    , uses = None Text
+    , run = Some "sbt ci-release"
+    , env = Some
+        ( toMap
+            { PGP_PASSPHRASE = "\${{ secrets.PGP_PASSPHRASE }}"
+            , PGP_SECRET = "\${{ secrets.PGP_SECRET }}"
+            , SONATYPE_PASSWORD = "\${{ secrets.SONATYPE_PASSWORD }}"
+            , SONATYPE_USERNAME = "\${{ secrets.SONATYPE_USERNAME }}"
+            }
+        )
+    }


### PR DESCRIPTION
I figured there's no point in parameterizing the values of the environment variables, which are always going to be the same with Github actions. They only change if you use a different CI.