### PR TITLE
Revert "Add missing id, run and uses Step default (#10)"

### DIFF
--- a/defaults/Step.dhall
+++ b/defaults/Step.dhall
@@ -13,7 +13,4 @@ in  { env = None Env
     , strategy = None Strategy
     , if = None Text
     , working-directory = None Text
-    , id = None Text
-    , uses = None Text
-    , run = None Text
     }

--- a/package.dhall
+++ b/package.dhall
@@ -1,4 +1,4 @@
-  ./schemas.dhall sha256:45702ab4e924307637a4e09584ca24775a7ae32f79e27683d3398db70637a456
+  ./schemas.dhall sha256:e23064d43ac3eecdf3bfd45aa4e17758a5edb979f0cb611e344d80bdca418156
 ∧ { steps =
       ./steps.dhall sha256:79ec5698a3e99cd4a7cd5bc71c619b95ec4b711c7cc2a1129dc69dbba24a4923
   }


### PR DESCRIPTION
This reverts commit 47a87565430fd820bbe91aed1423612a9771adf3 as it
conflicts with 78c97a2710fd3c46b03027069e909b6cb3392154.