### PR TITLE
Fix syntax errors for dhall@1.33.*; Reformat codebase with dhall format@1.33.*

### DIFF
--- a/defaults/Job.dhall
+++ b/defaults/Job.dhall
@@ -11,5 +11,5 @@ in  { name = None Text
     , env = None Env
     , defaults = None Defaults
     , timeout-minutes = None Natural
-    , if = None Text
+    , `if` = None Text
     }

--- a/defaults/Step.dhall
+++ b/defaults/Step.dhall
@@ -9,8 +9,8 @@ in  { env = None Env
     , run = None Text
     , uses = None Text
     , continue-on-error = None Bool
-    , with = None (List { mapKey : Text, mapValue : Text })
+    , `with` = None (List { mapKey : Text, mapValue : Text })
     , strategy = None Strategy
-    , if = None Text
+    , `if` = None Text
     , working-directory = None Text
     }

--- a/steps/JamesIves/ghpages-deploy.dhall
+++ b/steps/JamesIves/ghpages-deploy.dhall
@@ -33,7 +33,7 @@ in  λ ( args
       , name = Some "Deploy 🚀"
       , uses = Some "JamesIves/github-pages-deploy-action@3.5.3"
       , run = None Text
-      , with = Some
+      , `with` = Some
           (   toMap { BRANCH = args.branch, FOLDER = args.folder }
             # auth args.authSchema
             # opts args.opts

--- a/steps/actions/cache.dhall
+++ b/steps/actions/cache.dhall
@@ -6,7 +6,7 @@ in    λ(args : { path : Text, key : Text, hashFile : Text })
       , name = Some "${args.path} cache"
       , uses = Some "actions/cache@v1"
       , run = None Text
-      , with = Some
+      , `with` = Some
           ( toMap
               { path = args.path
               , key =

--- a/steps/actions/cache.dhall
+++ b/steps/actions/cache.dhall
@@ -1,7 +1,7 @@
 let Step = ../../schemas/Step.dhall
 
-in    λ(args : { path : Text, key : Text, hashFile : Text })
-    → Step::{
+in  λ(args : { path : Text, key : Text, hashFile : Text }) →
+      Step::{
       , id = None Text
       , name = Some "${args.path} cache"
       , uses = Some "actions/cache@v1"

--- a/steps/actions/checkout.dhall
+++ b/steps/actions/checkout.dhall
@@ -5,5 +5,5 @@ in  Step::{
     , name = None Text
     , uses = Some "actions/checkout@v2.1.0"
     , run = None Text
-    , with = None (List { mapKey : Text, mapValue : Text })
+    , `with` = None (List { mapKey : Text, mapValue : Text })
     }

--- a/steps/actions/helloWorld.dhall
+++ b/steps/actions/helloWorld.dhall
@@ -1,7 +1,7 @@
 let Step = ../../schemas/Step.dhall
 
-in    λ(args : { name : Text, who-to-greet : Text })
-    → Step::{
+in  λ(args : { name : Text, who-to-greet : Text }) →
+      Step::{
       , id = None Text
       , name = Some args.name
       , run = None Text

--- a/steps/actions/helloWorld.dhall
+++ b/steps/actions/helloWorld.dhall
@@ -6,5 +6,5 @@ in    λ(args : { name : Text, who-to-greet : Text })
       , name = Some args.name
       , run = None Text
       , uses = Some "actions/hello-world-javascript-action@v1"
-      , with = Some (toMap { who-to-greet = args.who-to-greet })
+      , `with` = Some (toMap { who-to-greet = args.who-to-greet })
       }

--- a/steps/actions/java-setup.dhall
+++ b/steps/actions/java-setup.dhall
@@ -6,7 +6,7 @@ in    λ(args : { java-version : Text })
       , name = Some "java ${args.java-version} setup"
       , uses = Some "actions/setup-java@v1"
       , run = None Text
-      , with = Some
+      , `with` = Some
           ( toMap
               { java-version = args.java-version
               , java-package = "jdk"

--- a/steps/actions/java-setup.dhall
+++ b/steps/actions/java-setup.dhall
@@ -1,7 +1,7 @@
 let Step = ../../schemas/Step.dhall
 
-in    λ(args : { java-version : Text })
-    → Step::{
+in  λ(args : { java-version : Text }) →
+      Step::{
       , id = None Text
       , name = Some "java ${args.java-version} setup"
       , uses = Some "actions/setup-java@v1"

--- a/steps/cache.dhall
+++ b/steps/cache.dhall
@@ -1,7 +1,7 @@
 let Step = ../schemas/Step.dhall
 
-in    λ(args : { path : Text, key : Text, hashFile : Text })
-    → Step::{
+in  λ(args : { path : Text, key : Text, hashFile : Text }) →
+      Step::{
       , id = None Text
       , name = Some "${args.path} cache"
       , uses = Some "actions/cache@v1"

--- a/steps/cache.dhall
+++ b/steps/cache.dhall
@@ -6,7 +6,7 @@ in    λ(args : { path : Text, key : Text, hashFile : Text })
       , name = Some "${args.path} cache"
       , uses = Some "actions/cache@v1"
       , run = None Text
-      , with = Some
+      , `with` = Some
           ( toMap
               { path = args.path
               , key =

--- a/steps/cachix/cachix.dhall
+++ b/steps/cachix/cachix.dhall
@@ -6,7 +6,7 @@ in  λ(args : { cache-name : Text }) →
       , name = None Text
       , uses = Some "cachix/cachix-action@v6"
       , run = None Text
-      , with = Some
+      , `with` = Some
           ( toMap
               { name = args.cache-name
               , signingKey = "\${{ secrets.CACHIX_SIGNING_KEY }}"

--- a/steps/cachix/install-nix.dhall
+++ b/steps/cachix/install-nix.dhall
@@ -5,5 +5,5 @@ in  Step::{
     , name = None Text
     , uses = Some "cachix/install-nix-action@v9"
     , run = None Text
-    , with = None (List { mapKey : Text, mapValue : Text })
+    , `with` = None (List { mapKey : Text, mapValue : Text })
     }

--- a/steps/checkout.dhall
+++ b/steps/checkout.dhall
@@ -5,5 +5,5 @@ in  Step::{
     , name = None Text
     , uses = Some "actions/checkout@v2.1.0"
     , run = None Text
-    , with = None (List { mapKey : Text, mapValue : Text })
+    , `with` = None (List { mapKey : Text, mapValue : Text })
     }

--- a/steps/echo.dhall
+++ b/steps/echo.dhall
@@ -1,5 +1,5 @@
 let run = ./run.dhall
 
-in    λ(args : { name : Text, what : Text })
-    →   run { run = "echo ${args.what}" }
+in  λ(args : { name : Text, what : Text }) →
+        run { run = "echo ${args.what}" }
       ⫽ { id = None Text, name = Some args.name }

--- a/steps/elastic/elasticsearch.dhall
+++ b/steps/elastic/elasticsearch.dhall
@@ -14,6 +14,6 @@ in      \(args : { stack-version : Text, nodes : Optional Natural })
             , name = Some "Runs elasticsearch version ${args.stack-version}"
             , uses = Some "elastic/elastic-github-actions/elasticsearch@master"
             , run = None Text
-            , with = Some
+            , `with` = Some
                 (toMap { stack-version = args.stack-version } # nodes-vars)
             }

--- a/steps/elastic/elasticsearch.dhall
+++ b/steps/elastic/elasticsearch.dhall
@@ -1,19 +1,18 @@
 let Step = ../../schemas/Step.dhall
 
-in      \(args : { stack-version : Text, nodes : Optional Natural })
-    ->  let nodes-vars =
-              merge
-                { None = [] : List { mapKey : Text, mapValue : Text }
-                , Some =
-                    \(nodes : Natural) -> toMap { nodes = Natural/show nodes }
-                }
-                args.nodes
+in  λ(args : { stack-version : Text, nodes : Optional Natural }) →
+      let nodes-vars =
+            merge
+              { None = [] : List { mapKey : Text, mapValue : Text }
+              , Some = λ(nodes : Natural) → toMap { nodes = Natural/show nodes }
+              }
+              args.nodes
 
-        in  Step::{
-            , id = None Text
-            , name = Some "Runs elasticsearch version ${args.stack-version}"
-            , uses = Some "elastic/elastic-github-actions/elasticsearch@master"
-            , run = None Text
-            , `with` = Some
-                (toMap { stack-version = args.stack-version } # nodes-vars)
-            }
+      in  Step::{
+          , id = None Text
+          , name = Some "Runs elasticsearch version ${args.stack-version}"
+          , uses = Some "elastic/elastic-github-actions/elasticsearch@master"
+          , run = None Text
+          , `with` = Some
+              (toMap { stack-version = args.stack-version } # nodes-vars)
+          }

--- a/steps/helloWorld.dhall
+++ b/steps/helloWorld.dhall
@@ -1,7 +1,7 @@
 let Step = ../schemas/Step.dhall
 
-in    λ(args : { name : Text, who-to-greet : Text })
-    → Step::{
+in  λ(args : { name : Text, who-to-greet : Text }) →
+      Step::{
       , id = None Text
       , name = Some args.name
       , run = None Text

--- a/steps/helloWorld.dhall
+++ b/steps/helloWorld.dhall
@@ -6,5 +6,5 @@ in    λ(args : { name : Text, who-to-greet : Text })
       , name = Some args.name
       , run = None Text
       , uses = Some "actions/hello-world-javascript-action@v1"
-      , with = Some (toMap { who-to-greet = args.who-to-greet })
+      , `with` = Some (toMap { who-to-greet = args.who-to-greet })
       }

--- a/steps/java-setup.dhall
+++ b/steps/java-setup.dhall
@@ -6,7 +6,7 @@ in    λ(args : { java-version : Text })
       , name = Some "java ${args.java-version} setup"
       , uses = Some "actions/setup-java@v1"
       , run = None Text
-      , with = Some
+      , `with` = Some
           ( toMap
               { java-version = args.java-version
               , java-package = "jdk"

--- a/steps/java-setup.dhall
+++ b/steps/java-setup.dhall
@@ -1,7 +1,7 @@
 let Step = ../schemas/Step.dhall
 
-in    λ(args : { java-version : Text })
-    → Step::{
+in  λ(args : { java-version : Text }) →
+      Step::{
       , id = None Text
       , name = Some "java ${args.java-version} setup"
       , uses = Some "actions/setup-java@v1"

--- a/steps/olafurpg/gpg-setup.dhall
+++ b/steps/olafurpg/gpg-setup.dhall
@@ -5,5 +5,5 @@ in  Step::{
     , name = None Text
     , uses = Some "olafurpg/setup-gpg@v2"
     , run = None Text
-    , with = None (List { mapKey : Text, mapValue : Text })
+    , `with` = None (List { mapKey : Text, mapValue : Text })
     }

--- a/steps/olafurpg/java-setup.dhall
+++ b/steps/olafurpg/java-setup.dhall
@@ -1,14 +1,10 @@
 let Step = ../../schemas/Step.dhall
 
-in    λ(args : { java-version : Text })
-    → Step::{
+in  λ(args : { java-version : Text }) →
+      Step::{
       , id = None Text
       , name = Some "java ${args.java-version} setup"
       , uses = Some "olafurpg/setup-java@v6"
       , run = None Text
-      , `with` = Some
-          ( toMap
-              { java-version = args.java-version
-              }
-          )
+      , `with` = Some (toMap { java-version = args.java-version })
       }

--- a/steps/olafurpg/java-setup.dhall
+++ b/steps/olafurpg/java-setup.dhall
@@ -6,7 +6,7 @@ in    λ(args : { java-version : Text })
       , name = Some "java ${args.java-version} setup"
       , uses = Some "olafurpg/setup-java@v6"
       , run = None Text
-      , with = Some
+      , `with` = Some
           ( toMap
               { java-version = args.java-version
               }

--- a/steps/run.dhall
+++ b/steps/run.dhall
@@ -1,7 +1,7 @@
 let Step = ../schemas/Step.dhall
 
-in    λ(args : { run : Text })
-    → Step::{
+in  λ(args : { run : Text }) →
+      Step::{
       , id = None Text
       , name = None Text
       , run = Some args.run

--- a/types/Job.dhall
+++ b/types/Job.dhall
@@ -17,5 +17,5 @@ in  { name : Optional Text
     , defaults : Optional Defaults
     , steps : List Step
     , timeout-minutes : Optional Natural
-    , if : Optional Text
+    , `if` : Optional Text
     }

--- a/types/On.dhall
+++ b/types/On.dhall
@@ -4,4 +4,7 @@ let PullRequest = ./events/PullRequest.dhall
 
 let Delete = ./events/Delete.dhall
 
-in  { push : Optional Push, pull_request : Optional PullRequest, delete : Optional Delete }
+in  { push : Optional Push
+    , pull_request : Optional PullRequest
+    , delete : Optional Delete
+    }

--- a/types/Step.dhall
+++ b/types/Step.dhall
@@ -12,9 +12,9 @@ in  { id : Optional Text
     , run : Optional Text
     , uses : Optional Text
     , shell : Optional Text
-    , with : Optional (List { mapKey : Text, mapValue : Text })
+    , `with` : Optional (List { mapKey : Text, mapValue : Text })
     , continue-on-error : Optional Bool
     , strategy : Optional Strategy
-    , if : Optional Text
+    , `if` : Optional Text
     , working-directory : Optional Text
     }

--- a/types/Strategy.dhall
+++ b/types/Strategy.dhall
@@ -1,1 +1,4 @@
-{ matrix : List { mapKey : Text, mapValue : List Text }, fail-fast : Optional Bool, max-parallel : Optional Natural }
+{ matrix : List { mapKey : Text, mapValue : List Text }
+, fail-fast : Optional Bool
+, max-parallel : Optional Natural
+}


### PR DESCRIPTION
## Context

Fields that are the same name as dhall keywords broke in `dhall-1.33` if not using backticks. In this codebase that meant: `with` and `if`.

## Description

👋 This makes importing this library possible for `dhall@1.33` I assume you want all the diff noise of a new formatter in one commit vs subsequent PRs.