### PR TITLE
Fix steps/actions/cache.dhall hash and restore

### DIFF
--- a/package.dhall
+++ b/package.dhall
@@ -1,6 +1,6 @@
   ./schemas.dhall sha256:01ede370725bafdd155584236621a13e78d8a211bfd7a81c64369f0e961e61fa
 ∧ { steps =
-      ./steps.dhall sha256:c3973d640eb4dbc53a590780c37dababee5463258a9bae59ff4108c11a742ca1
+      ./steps.dhall sha256:dc2177ddf776d481978da097f683b1fac61a910cc512648d594f7762e3c31c93
   }
 ∧ { types =
       ./types.dhall sha256:14aea50fde0d6077dc6fb9b0a71821a8b83e60174e11ad7dbf28d185713275c6

--- a/steps.dhall
+++ b/steps.dhall
@@ -3,9 +3,9 @@
 , echo =
     ./steps/echo.dhall sha256:87329eab26c14eac330e20cf5830070cf952a0e7eab4c0d8634d417044213ca3
 , actions/checkout =
-    ./steps/actions/checkout.dhall sha256:abec1b4d04950070c638b35d9d1be07b94ad6c10fe5b8a044404b2645d55f224
+    ./steps/actions/checkout.dhall sha256:9774916c906aeaf93189742e3626338410c7b8e8a5c497484c42b61ac77a72b3
 , actions/cache =
-    ./steps/actions/cache.dhall sha256:c9c2d75be011bd55a2915931cd808b433c62a3264490dc5047b2c2240e3cc2e4
+    ./steps/actions/cache.dhall sha256:ae1e58726fc2d13b079aaf90bc0e02071cdb1bd7b6dc7a6dc5255c9cdbb79e60
 , actions/helloWorld =
     ./steps/actions/helloWorld.dhall sha256:119e5f24031dd30ebf94b9a8c7cfda7ac1da271effff60dd9d7542f932ed5145
 , actions/setup-haskell =

--- a/steps/actions/cache.dhall
+++ b/steps/actions/cache.dhall
@@ -4,20 +4,23 @@ let Text/concatMapSep =
       https://prelude.dhall-lang.org/v17.1.0/Text/concatMapSep.dhall sha256:c272aca80a607bc5963d1fcb38819e7e0d3e72ac4d02b1183b1afb6a91340840
 
 in  λ(args : { path : Text, key : Text, hashFiles : List Text }) →
-      let hashFilesArg =
-            Text/concatMapSep "," Text (λ(x : Text) → "'${x}'") args.hashFiles
+      let keyPrefix = "\${{ runner.os }}-${args.key}-"
+
+      let quote = λ(x : Text) → "'${x}'"
+
+      let hashFilesArg = Text/concatMapSep ", " Text quote args.hashFiles
 
       in  Step::{
-          , id = None Text
           , name = Some "${args.path} cache"
-          , uses = Some "actions/cache@v2.1.3"
-          , run = None Text
+          , uses = Some "actions/cache@v2"
           , `with` = Some
               ( toMap
                   { path = args.path
-                  , key =
-                      "\${{ runner.os }}-${args.key}-\${{ hashFiles('${hashFilesArg}') }}"
-                  , restore-keys = args.key
+                  , key = "${keyPrefix}\${{ hashFiles(${hashFilesArg}) }}"
+                  , restore-keys =
+                      ''
+                      ${keyPrefix}
+                      ''
                   }
               )
           }

--- a/steps/actions/checkout.dhall
+++ b/steps/actions/checkout.dhall
@@ -1,9 +1,3 @@
 let Step = ../../schemas/Step.dhall
 
-in  Step::{
-    , id = None Text
-    , name = None Text
-    , uses = Some "actions/checkout@v2.3.4"
-    , run = None Text
-    , `with` = None (List { mapKey : Text, mapValue : Text })
-    }
+in  Step::{ uses = Some "actions/checkout@v2" }

--- a/steps/actions/helloWorld.dhall
+++ b/steps/actions/helloWorld.dhall
@@ -2,9 +2,7 @@ let Step = ../../schemas/Step.dhall
 
 in  λ(args : { name : Text, who-to-greet : Text }) →
       Step::{
-      , id = None Text
       , name = Some args.name
-      , run = None Text
       , uses = Some "actions/hello-world-javascript-action@v1"
       , `with` = Some (toMap { who-to-greet = args.who-to-greet })
       }


### PR DESCRIPTION
- Don't surround `${hashFilesArg}` with quotates.
- Use correct `restore-keys` value ("correct" = similar to those in https://github.com/actions/cache/blob/main/examples.md).

steps/actions/{checkout.dhall,helloWorld}: only mention fields with non-default values.