### PR TITLE
Move to haskell/actions/setup

### DIFF
--- a/defaults/actions/HaskellSetup.dhall
+++ b/defaults/actions/HaskellSetup.dhall
@@ -4,4 +4,5 @@
 , enable-stack = None Bool
 , stack-no-global = None Bool
 , stack-setup-ghc = None Bool
+, disable-matcher = None Bool
 }

--- a/package.dhall
+++ b/package.dhall
@@ -1,7 +1,7 @@
-  ./schemas.dhall sha256:502a5a2ab029235e5200eb4b808e06e3d7301ff24eacc78f6f2a202a615741be
+  ./schemas.dhall sha256:e83adc0d3858251575b1a1bd779d39ca7894546df3711b811de24f9b59f65868
 ∧ { steps =
-      ./steps.dhall sha256:0c201bc5191a14cd12e1c735e2ce50f0669a64f53469597ebddd4a4794da04a5
+      ./steps.dhall sha256:2e0856b0ba49e7c85aeafd7af75b6a69f2fcd8bacf30e4ca2dda84058d5062ad
   }
 ∧ { types =
-      ./types.dhall sha256:0a5f023d40079e8fd4d24562055fdbde4e944e8c9d5212be5354a78a2b411bde
+      ./types.dhall sha256:3bc434865875a288f34201cbdb5c18135435c78e01bb7d7c5d431b0234c81373
   }

--- a/schemas.dhall
+++ b/schemas.dhall
@@ -21,5 +21,5 @@
 , Schedule =
     ./schemas/events/Schedule.dhall sha256:03caaa6deeed4018094f9a77b2db6f49c28ca75874c44e2256e8147894c30746
 , actions/HaskellSetup =
-    ./schemas/actions/HaskellSetup.dhall sha256:e9f6bf0b692ac664f21bf4c8e6d92ff87cdf22e29772651e1ad98e4eb4a95f7e
+    ./schemas/actions/HaskellSetup.dhall sha256:e6dbbacedf33965f5005dc2a22164d0a5edb3e09b2b4842104cec011c6d3c95d
 }

--- a/steps.dhall
+++ b/steps.dhall
@@ -8,8 +8,7 @@
     ./steps/actions/cache.dhall sha256:f4744a6760fcaa0c65acdbf6ead1afd77161352404181b1e041ba6f7d4053775
 , actions/helloWorld =
     ./steps/actions/helloWorld.dhall sha256:119e5f24031dd30ebf94b9a8c7cfda7ac1da271effff60dd9d7542f932ed5145
-, actions/setup-haskell =
-    ./steps/actions/setup-haskell.dhall sha256:d451f45c814a935e8f030cf1cd1a4b7beea6836ff37d64030a708c7bc781fb56
+, actions/setup-haskell = ./steps/actions/setup-haskell.dhall
 , actions/setup-java =
     ./steps/actions/setup-java.dhall sha256:615313f503d88f81f16f4715a45afccfc6c718a46e373ae74f16d4a8895b6592
 , cachix/cachix =

--- a/steps/actions/setup-haskell.dhall
+++ b/steps/actions/setup-haskell.dhall
@@ -18,7 +18,7 @@ let haskell-setup
     : HaskellSetup.Type → Step.Type
     = λ(args : HaskellSetup.Type) →
         Step::{
-        , uses = Some "actions/setup-haskell@v1"
+        , uses = Some "haskell/actions/setup@v1"
         , `with` = Some
             ( List/concatMap
                 (Map.Entry Text (Optional Text))
@@ -37,6 +37,7 @@ let haskell-setup
                     , enable-stack = stringBool args.enable-stack
                     , stack-no-global = stringBool args.stack-no-global
                     , stack-setup-ghc = stringBool args.stack-setup-ghc
+                    , disable-matcher = stringBool args.disable-matcher
                     }
                 )
             )

--- a/types.dhall
+++ b/types.dhall
@@ -25,5 +25,5 @@
 , Schedule =
     ./types/events/Schedule.dhall sha256:eb91edc996fadffb9cac1b67a4da220eed6bf54e96f7b8accbb613462e402537
 , actions/HaskellSetup =
-    ./types/actions/HaskellSetup.dhall sha256:d2772ae99c9bd50de89a9a964f132627bb264aea01670263e9c04d241bab79de
+    ./types/actions/HaskellSetup.dhall sha256:3cfef5c383d40623d0766715715c881583623bf6e11a0ad0b9946d8eaeffa6c5
 }

--- a/types/actions/HaskellSetup.dhall
+++ b/types/actions/HaskellSetup.dhall
@@ -4,4 +4,5 @@
 , enable-stack : Optional Bool
 , stack-no-global : Optional Bool
 , stack-setup-ghc : Optional Bool
+, disable-matcher : Optional Bool
 }


### PR DESCRIPTION
[actions/setup-haskell](https://github.com/actions/setup-haskell) is unsupported and suggests use of [haskell/actions](https://github.com/haskell/actions) instead.

This PR works as far as I have checked, but I don't claim that this is a good direction for github-actions-dhall.