### PR TITLE
add workflow_dispatch event

### DIFF
--- a/defaults.dhall
+++ b/defaults.dhall
@@ -1,7 +1,7 @@
 { Job =
     ./defaults/Job.dhall sha256:c57992fad0522ae3bf33b7e36f344d2b4b27732fc14189bbd2f51763dd69d202
 , On =
-    ./defaults/On.dhall sha256:5739587ac92ecba0e8d26cdfff2811b85b0ed8c0cf3fcf08dae55b2d96f6f324
+    ./defaults/On.dhall sha256:c22e1058d01a77f2cd49c29a68c082087c0961734a3710861eac93d19c480a17
 , Step =
     ./defaults/Step.dhall sha256:d65cc1e58f7721dcc11749bcb51b47ca94c33db04805477a48819a259ca68dfb
 , Service =
@@ -16,6 +16,10 @@
     ./defaults/events/Delete.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , Schedule =
     ./defaults/events/Schedule.dhall sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
+, Input =
+    ./defaults/Input.dhall sha256:047d951f9f951543458f7dd6ceffb5d53585fe2d59ff2a1616e8f4e130615f1a
+, WorkflowDispatch =
+    ./defaults/events/WorkflowDispatch.dhall sha256:2133dc321eb5b06cd0c9ffb6cd412fa1dfd7e20c4341fecbff2b17ce29119958
 , actions/HaskellSetup =
     ./defaults/actions/HaskellSetup.dhall sha256:e0762bf1442388cce1187fbac3e606685337f45b0e69251cfa33e513dc03c709
 }

--- a/defaults/Input.dhall
+++ b/defaults/Input.dhall
@@ -1,0 +1,1 @@
+{ description = None Text, default = None Text, required = False }

--- a/defaults/On.dhall
+++ b/defaults/On.dhall
@@ -6,8 +6,11 @@ let Delete = ../types/events/Delete.dhall
 
 let Schedule = ../types/events/Schedule.dhall
 
+let WorkflowDispatch = ../types/events/WorkflowDispatch.dhall
+
 in  { push = None Push
     , pull_request = None PullRequest
     , delete = None Delete
     , schedule = None (List Schedule)
+    , workflow_dispatch = None WorkflowDispatch
     }

--- a/defaults/events/WorkflowDispatch.dhall
+++ b/defaults/events/WorkflowDispatch.dhall
@@ -1,0 +1,1 @@
+{ inputs = None (List { mapKey : Text, mapValue : ../../types/Input.dhall }) }

--- a/package.dhall
+++ b/package.dhall
@@ -1,7 +1,7 @@
-  ./schemas.dhall sha256:e83adc0d3858251575b1a1bd779d39ca7894546df3711b811de24f9b59f65868
+  ./schemas.dhall sha256:36c20302ee31979233621e1db84c50a56469cdcfc82e9937642640aa13c03b71
 ∧ { steps =
       ./steps.dhall sha256:2e0856b0ba49e7c85aeafd7af75b6a69f2fcd8bacf30e4ca2dda84058d5062ad
   }
 ∧ { types =
-      ./types.dhall sha256:3bc434865875a288f34201cbdb5c18135435c78e01bb7d7c5d431b0234c81373
+      ./types.dhall sha256:ddd3f011c6e5fa19f93c36a429313680baf547c9f3cdd5f66d19e1ffa353640f
   }

--- a/schemas.dhall
+++ b/schemas.dhall
@@ -1,7 +1,7 @@
 { Job =
     ./schemas/Job.dhall sha256:c97c5a27645e727e95af15a76cc355e39d18b4570e59399b2b840e4efa10dffb
 , On =
-    ./schemas/On.dhall sha256:0119d8206603dd7b789795b3a818cdd880a0036331703eef04241d8b2e78264d
+    ./schemas/On.dhall sha256:07483e42b9fc6d789e2fa1cd7e1c50c988aa35d74546649088c72f05235c6fe1
 , RunsOn =
     ./schemas/RunsOn.dhall sha256:95330e5033cd7c44f4a3f2d0595e4dc1e3c8f0b5c15210fd510578e7ba60428d
 , Step =
@@ -11,7 +11,7 @@
 , Service =
     ./schemas/Service.dhall sha256:ccf7857f3b39aba24ae09b6eb2b430c96be6b3bc697ed6f0bae464e1e7bdff82
 , Workflow =
-    ./schemas/Workflow.dhall sha256:7086e489aa53557a54c335e63e8ceb8bd3b8549d4033d2acd6333faba89d2af5
+    ./schemas/Workflow.dhall sha256:f1ae5984391273d438b81028da6580e3c9be9f65ba3713dd4a924a3a1bb67942
 , Push =
     ./schemas/events/Push.dhall sha256:59aa648eda0a6e47e8b03074d1ec35e910f0b177bf1104fb545f5225f543dd95
 , PullRequest =
@@ -20,6 +20,10 @@
     ./schemas/events/Delete.dhall sha256:81a1bf11fb9dc588941bd83400ed571298585a700a53e858456806f7ea3b8ce2
 , Schedule =
     ./schemas/events/Schedule.dhall sha256:03caaa6deeed4018094f9a77b2db6f49c28ca75874c44e2256e8147894c30746
+, Input =
+    ./schemas/Input.dhall sha256:f15ab36ac38cb32a757173088ec95050e3cb3fe8765bd1d4cc49851cec7877d8
+, WorkflowDispatch =
+    ./schemas/events/WorkflowDispatch.dhall sha256:f3243d9aaa461034e9844d51fb4e2c646a956ea3df2d1f12ae31e16ee29b1a55
 , actions/HaskellSetup =
     ./schemas/actions/HaskellSetup.dhall sha256:e6dbbacedf33965f5005dc2a22164d0a5edb3e09b2b4842104cec011c6d3c95d
 }

--- a/schemas/Input.dhall
+++ b/schemas/Input.dhall
@@ -1,0 +1,1 @@
+{ Type = ../types/Input.dhall, default = ../defaults/Input.dhall }

--- a/schemas/events/WorkflowDispatch.dhall
+++ b/schemas/events/WorkflowDispatch.dhall
@@ -1,0 +1,3 @@
+{ Type = ../../types/events/WorkflowDispatch.dhall
+, default = ../../defaults/events/WorkflowDispatch.dhall
+}

--- a/types.dhall
+++ b/types.dhall
@@ -5,7 +5,7 @@
 , Strategy =
     ./types/Strategy.dhall sha256:060bf27380c527f136c2c86ba1cf1f7cab6ad3dd339e655db0873cc8068b7b9d
 , On =
-    ./types/On.dhall sha256:aa6c13340d565fcc585350e0fec57d0870cb2181c8c7894ccd1fedecee0c116c
+    ./types/On.dhall sha256:04a799b6766840be1b43c4b526641ed84879b476818a9a591fcfd2f9730274e1
 , Step =
     ./types/Step.dhall sha256:54f06c3c6ff505780eb30547e29288a4e8b96b29913f77fd086b4652c002bdda
 , RunsOn =
@@ -15,7 +15,7 @@
 , Service =
     ./types/Service.dhall sha256:c957b80c6a0d53dce7bf05921c1983797b5d52958ded76244cd94ae80deb94e5
 , Workflow =
-    ./types/Workflow.dhall sha256:9b36457a707fcfec6cbd80d743b470756074718dc274adc6a29360494e6e164c
+    ./types/Workflow.dhall sha256:cea7de5532b2a48b3aa71c45beb19546263634d6e7e08cf4ceca28f1c8de5cd4
 , Push =
     ./types/events/Push.dhall sha256:8fbd99245e6d2a3ec558ebde1596c37e0666c163e02a3577f8f7df1cfee0e100
 , PullRequest =
@@ -24,6 +24,10 @@
     ./types/events/Delete.dhall sha256:0912602a19e01dcff30f351958d2d9b69519c9be61b57b1b32a2a569bf8bf5f9
 , Schedule =
     ./types/events/Schedule.dhall sha256:eb91edc996fadffb9cac1b67a4da220eed6bf54e96f7b8accbb613462e402537
+, Input =
+    ./types/Input.dhall sha256:4723eaffcfb407926dbda34ad46b0e4159885063a24aa26351fd86417a150c4a
+, WorkflowDispatch =
+    ./types/events/WorkflowDispatch.dhall sha256:6a5553c84dd7397eb24b3f94326d9ae9cfae04ace8fa55606319ee312d023ef8
 , actions/HaskellSetup =
     ./types/actions/HaskellSetup.dhall sha256:3cfef5c383d40623d0766715715c881583623bf6e11a0ad0b9946d8eaeffa6c5
 }

--- a/types/Input.dhall
+++ b/types/Input.dhall
@@ -1,0 +1,1 @@
+{ description : Optional Text, required : Bool, default : Optional Text }

--- a/types/On.dhall
+++ b/types/On.dhall
@@ -6,8 +6,11 @@ let Delete = ./events/Delete.dhall
 
 let Schedule = ./events/Schedule.dhall
 
+let WorkflowDispatch = ./events/WorkflowDispatch.dhall
+
 in  { push : Optional Push
     , pull_request : Optional PullRequest
     , delete : Optional Delete
     , schedule : Optional (List Schedule)
+    , workflow_dispatch : Optional WorkflowDispatch
     }

--- a/types/events/WorkflowDispatch.dhall
+++ b/types/events/WorkflowDispatch.dhall
@@ -1,0 +1,1 @@
+{ inputs : Optional (List { mapKey : Text, mapValue : ../Input.dhall }) }


### PR DESCRIPTION
Adds [workflow_dispatch](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) type, with ability to specify [inputs](https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#using-inputs-and-outputs-with-an-action)

---

As an aside, it does feel rather exhausting to have to mirror every new thing in all 3 places, a `type`, `default` and `schema`.

In my own dhall code, I typically just have e.g. `Input.dhall` which is the schema, as in:

```dhall
let Input = { description : Optional Text, required : Bool, default : Optional Text }

let default = { description = None Text, required = False, default = None Text }

in { Type = Input, default }
```

It's much easier for me to work on, since everything related to this concept is right there, and there's much less cross-referencing.

Obviously I only import `./schemas.dhall`, I suppose anyone who only imports `types` will find the extra `.Type` fields a little inconvenient, but I don't imagine this is common practice.
Does anyone import `defaults.dhall` directly? I can't imagine a use for it.

---

Also the `freeze` make task still suffers from ordering problems, which causes mismatches if you don't have the current versions in your dhall cache:

```sh
$ make
dhall freeze --all --inplace defaults.dhall
dhall freeze --all --inplace package.dhall
dhall:
↳ ./types.dhall
  ↳ ./types/Workflow.dhall sha256:9b36457a707fcfec6cbd80d743b470756074718dc274adc6a29360494e6e164c

Error: Import integrity check failed

Expected hash:

↳ 9b36457a707fcfec6cbd80d743b470756074718dc274adc6a29360494e6e164c

Actual hash:

↳ 5dcb19d442c22d1f9c8b56db909f76aa6c197184494c782d3f3fedbfd56f7d14


18│     ./types/Workflow.dhall sha256:9b36457a707fcfec6cbd80d743b470756074718dc274adc6a29360494e6e164c
```

(I had to manually `make` various `filename.dhall.freezed` to force the freezing to happen in the right order)