### PR TITLE
Fix minor naming inconsistency in actions/cache

### DIFF
--- a/package.dhall
+++ b/package.dhall
@@ -1,6 +1,6 @@
   ./schemas.dhall sha256:e83adc0d3858251575b1a1bd779d39ca7894546df3711b811de24f9b59f65868
 ∧ { steps =
-      ./steps.dhall sha256:2e0856b0ba49e7c85aeafd7af75b6a69f2fcd8bacf30e4ca2dda84058d5062ad
+      ./steps.dhall sha256:b3fbc1e0c940600fc9e7e5ef2384032f3710dd95296165d07a66a012cf501caa
   }
 ∧ { types =
       ./types.dhall sha256:3bc434865875a288f34201cbdb5c18135435c78e01bb7d7c5d431b0234c81373

--- a/steps.dhall
+++ b/steps.dhall
@@ -5,7 +5,7 @@
 , actions/checkout =
     ./steps/actions/checkout.dhall sha256:9774916c906aeaf93189742e3626338410c7b8e8a5c497484c42b61ac77a72b3
 , actions/cache =
-    ./steps/actions/cache.dhall sha256:f4744a6760fcaa0c65acdbf6ead1afd77161352404181b1e041ba6f7d4053775
+    ./steps/actions/cache.dhall sha256:b87c5b64159fbfb06f0cc4e303791f726c81c25f0b54b42f609251b966f7171b
 , actions/helloWorld =
     ./steps/actions/helloWorld.dhall sha256:119e5f24031dd30ebf94b9a8c7cfda7ac1da271effff60dd9d7542f932ed5145
 , actions/setup-haskell =

--- a/steps/actions/cache.dhall
+++ b/steps/actions/cache.dhall
@@ -7,7 +7,7 @@ let List/null =
       https://prelude.dhall-lang.org/v17.1.0/List/null.dhall sha256:2338e39637e9a50d66ae1482c0ed559bbcc11e9442bfca8f8c176bbcd9c4fc80
 
 in  λ(args : { path : Text, key : Text, hashFiles : List Text }) →
-      let keyComponent = "\${{ runner.os }}-${args.key}-"
+      let keyComponent = "\${{ runner.os }}-${args.key}"
 
       let quote = λ(x : Text) → "'${x}'"
 
@@ -16,7 +16,7 @@ in  λ(args : { path : Text, key : Text, hashFiles : List Text }) →
       let hashFilesComponent =
             if    List/null Text args.hashFiles
             then  ""
-            else  "\${{ hashFiles(${hashFilesArg}) }}"
+            else  "-\${{ hashFiles(${hashFilesArg}) }}"
 
       in  Step::{
           , name = Some "${args.path} cache"


### PR DESCRIPTION
We shouldn't append trailing dash to `keyComponent` in case `hashFiles` is empty, for instance:

```dhall
let cacheFoo =
      GithubActions.steps.actions/cache
        { path = "./install"
        , key = "foo-XXX"
        , hashFiles = [] : List Text
        }
```

Otherwise, `key` and `restore-keys` will look bad: `${{ runner.os }}-foo-XXX-`.