### PR TITLE
Additional concurrency support

### DIFF
--- a/defaults/Concurrency.dhall
+++ b/defaults/Concurrency.dhall
@@ -1,0 +1,1 @@
+{ group = None, cancel-in-progress = False }

--- a/defaults/Env.dhall
+++ b/defaults/Env.dhall
@@ -1,0 +1,2 @@
+None
+  ../types/Env.dhall sha256:e73a2ec07449acffe1a4ba9cd261b845a8beb8f81fbc1415575639e99da668e6

--- a/defaults/Job.dhall
+++ b/defaults/Job.dhall
@@ -1,3 +1,5 @@
+let Concurrency = ../types/Concurrency.dhall
+
 let Container = ../types/Container.dhall
 
 let Defaults = ../types/Defaults.dhall
@@ -18,4 +20,5 @@ in  { name = None Text
     , `if` = None Text
     , services = None (List { mapKey : Text, mapValue : Service })
     , container = None Container
+    , concurrency = None Concurrency
     }

--- a/package.dhall
+++ b/package.dhall
@@ -1,7 +1,7 @@
-  ./schemas.dhall sha256:3c383792e2303465b8db2d38579778988515dbe6395177c7f626e945872bee62
+  ./schemas.dhall sha256:9b317aeab4a2db1b680b27774799f1e43f3c94294e5d350285a6d0676317978a
 ∧ { steps =
       ./steps.dhall sha256:b3fbc1e0c940600fc9e7e5ef2384032f3710dd95296165d07a66a012cf501caa
   }
 ∧ { types =
-      ./types.dhall sha256:ceceb6f099d3bcbe233b208844166a1c15e71d88a1c86f53027de5b1cd7ec7cd
+      ./types.dhall sha256:5579ff4830dbfcb72ac5e7cafaf439ee44bcd982b3f3fc1407e900034722280b
   }

--- a/schemas.dhall
+++ b/schemas.dhall
@@ -1,9 +1,9 @@
 { Job =
-    ./schemas/Job.dhall sha256:c97c5a27645e727e95af15a76cc355e39d18b4570e59399b2b840e4efa10dffb
+    ./schemas/Job.dhall sha256:7d1c476fa1af0109b9e7faf740e1c0abd074e5b631832c8d1311a5f80a97a048
 , On =
     ./schemas/On.dhall sha256:86c35e1c12fca32d5fa4d605b60fe75f69d6ce0eb54fdb2ae7c8c5ea7afa6652
 , RunsOn =
-    ./schemas/RunsOn.dhall sha256:95330e5033cd7c44f4a3f2d0595e4dc1e3c8f0b5c15210fd510578e7ba60428d
+    ./schemas/RunsOn.dhall sha256:86f5d1f0c5dc24b2033237a9194f70b14326d6bae031bd44a0630e45dd3a4b3a
 , Step =
     ./schemas/Step.dhall sha256:16dad11fe1fd6a7593a26ecc40ce3fdb6e6babacb4f6eb06aeb0b83ed2e15821
 , Strategy =
@@ -11,7 +11,7 @@
 , Service =
     ./schemas/Service.dhall sha256:ccf7857f3b39aba24ae09b6eb2b430c96be6b3bc697ed6f0bae464e1e7bdff82
 , Workflow =
-    ./schemas/Workflow.dhall sha256:07bdccd484d41f6576c0a9112593aaa7d77d880c54fbea8f6f009ac3b7410166
+    ./schemas/Workflow.dhall sha256:29b2f8a932e460421f4303b90c68a4d63383d26836845f8141f7ae56cc8829dc
 , Push =
     ./schemas/events/Push.dhall sha256:3c33a2e62eaf486ef35cec2344dac9c5c5ec032470b92714018803f9824db9a0
 , PullRequest =
@@ -26,4 +26,6 @@
     ./schemas/events/WorkflowDispatch.dhall sha256:f3243d9aaa461034e9844d51fb4e2c646a956ea3df2d1f12ae31e16ee29b1a55
 , actions/HaskellSetup =
     ./schemas/actions/HaskellSetup.dhall sha256:e6dbbacedf33965f5005dc2a22164d0a5edb3e09b2b4842104cec011c6d3c95d
+, Concurrency =
+    ./schemas/Concurrency.dhall sha256:2ed562a8c402ad394223c57857e52915ab16b94775dfc0f4d277f227b6c6d450
 }

--- a/schemas/Concurrency.dhall
+++ b/schemas/Concurrency.dhall
@@ -1,0 +1,1 @@
+{ Type = ../types/Concurrency.dhall, default = ../defaults/Concurrency.dhall }

--- a/schemas/Env.dhall
+++ b/schemas/Env.dhall
@@ -1,0 +1,1 @@
+{ Type = ../types/Env.dhall, default = ../defaults/Env.dhall }

--- a/types.dhall
+++ b/types.dhall
@@ -1,5 +1,5 @@
 { Job =
-    ./types/Job.dhall sha256:8ace27f04e30a801a03657c43dd0d7c239a885c5c919a4595bedfcbe5f1d1555
+    ./types/Job.dhall sha256:511278f612a5a880dc9e6b3770ed1efec45e9bac01eb5b4417d305996bf88e26
 , Defaults =
     ./types/Defaults.dhall sha256:a2963761aaa06bae9abd5575667afbba6539d8ce694a4a82900bf4f9df2e7932
 , Strategy =
@@ -9,13 +9,13 @@
 , Step =
     ./types/Step.dhall sha256:54f06c3c6ff505780eb30547e29288a4e8b96b29913f77fd086b4652c002bdda
 , RunsOn =
-    ./types/RunsOn.dhall sha256:bba6f1d239ae641dff997a307432a2bb753bf8367bb6aae27c74c8ca53a7cac8
+    ./types/RunsOn.dhall sha256:9efc5b4e1cc4ce2f06aa59c77ae4f9fb47287d79b65c8469dbfa375af9eb21e8
 , Env =
     ./types/Env.dhall sha256:e73a2ec07449acffe1a4ba9cd261b845a8beb8f81fbc1415575639e99da668e6
 , Service =
     ./types/Service.dhall sha256:c957b80c6a0d53dce7bf05921c1983797b5d52958ded76244cd94ae80deb94e5
 , Workflow =
-    ./types/Workflow.dhall sha256:300e6ec3ccc96086b38b2b64c166771569a1e7f31f96e1b9fbe876e9e4584bf2
+    ./types/Workflow.dhall sha256:ae01ab28ef78d34582e70a868f025fa9b7da9196bbd26130ccc1ef6e9b1502c5
 , Push =
     ./types/events/Push.dhall sha256:b485c8921e0fb738a0e3714c74c897db7c0328dc7faae5ab7c0dec3ea0a71bde
 , PullRequest =

--- a/types/Job.dhall
+++ b/types/Job.dhall
@@ -1,3 +1,5 @@
+let Concurrency = ./Concurrency.dhall
+
 let Container = ./Container.dhall
 
 let Defaults = ./Defaults.dhall
@@ -24,4 +26,5 @@ in  { name : Optional Text
     , `if` : Optional Text
     , services : Optional (List { mapKey : Text, mapValue : Service })
     , container : Optional Container
+    , concurrency : Optional Concurrency
     }

--- a/types/RunsOn.dhall
+++ b/types/RunsOn.dhall
@@ -1,6 +1,7 @@
 < windows-latest
 | windows-2019
 | ubuntu-latest
+| `ubuntu-20.04`
 | `ubuntu-18.04`
 | `ubuntu-16.04`
 | macos-latest


### PR DESCRIPTION
I wasn't able to use the Concurrency type without adding a schema for it.

I also added the concurrency field to the Job type, which is supported by Github Actions

While here, I also added the `ubuntu-20.04` runner type