### PR TITLE
Add permissions to workflow keys

### DIFF
--- a/defaults/Workflow.dhall
+++ b/defaults/Workflow.dhall
@@ -4,4 +4,13 @@ let Defaults = ../types/Defaults.dhall
 
 let Concurrency = ../types/Concurrency.dhall
 
-in  { env = None Env, defaults = None Defaults, concurrency = None Concurrency }
+let Permission = ../types/Permission.dhall
+
+let PermissionAccess = ../types/PermissionAccess.dhall
+
+in  { env = None Env
+    , defaults = None Defaults
+    , concurrency = None Concurrency
+    , permissions =
+        None (List { mapKey : Permission, mapValue : PermissionAccess })
+    }

--- a/package.dhall
+++ b/package.dhall
@@ -1,10 +1,10 @@
     ./schemas.dhall
-      sha256:8faec3196331b72a6075043e386b0d1e931a9d83556a1f9ad400a8a538c141b5
+      sha256:47aff2c2c34ae546b942dd0e8c7e579a2fb1a6ad41fd81b621a208b5b94e383f
 /\  { steps =
         ./steps.dhall
           sha256:eba32baba369939e7fb57923fe1b60cea0d38fcc5531acf966561397e0613d41
     }
 /\  { types =
         ./types.dhall
-          sha256:c8b27734d6a439d4a4f484ff4c7735991bdc63fe1e8c72c7eb086b06ebe59263
+          sha256:ec4ee6be1fe873910bdc90e29689dde6945b5520ae72e64061cb92341f69eb42
     }

--- a/schemas.dhall
+++ b/schemas.dhall
@@ -21,7 +21,7 @@
       sha256:ccf7857f3b39aba24ae09b6eb2b430c96be6b3bc697ed6f0bae464e1e7bdff82
 , Workflow =
     ./schemas/Workflow.dhall
-      sha256:46f8087bf073335f43c880ec14a5e924b1576a4743c993342b7cc8de2523729a
+      sha256:5f3f6f11f73fc99914094889140f9de47e1c55d9aee112ad8556e21dda5c1012
 , Push =
     ./schemas/events/Push.dhall
       sha256:42b2efddec698fbb36321e738286478b35dfd9420ce10798659237570db55024

--- a/types.dhall
+++ b/types.dhall
@@ -27,7 +27,7 @@
       sha256:c957b80c6a0d53dce7bf05921c1983797b5d52958ded76244cd94ae80deb94e5
 , Workflow =
     ./types/Workflow.dhall
-      sha256:cf6bac3a376287e5cbd9c7ae94c8f60ba3d608ccff29bcf96dc563a9a8fa9c42
+      sha256:b75d2dcd4b2cf6be5149a3913006213eee1e50769f103eb34430d43162676b1a
 , Push =
     ./types/events/Push.dhall
       sha256:5147b1dd6eca94aae5d217b979cac20ba64b7ec160488dd917f171cae451b135

--- a/types/Workflow.dhall
+++ b/types/Workflow.dhall
@@ -8,10 +8,16 @@ let Defaults = ./Defaults.dhall
 
 let Job = ./Job.dhall
 
+let Permission = ./Permission.dhall
+
+let PermissionAccess = ./PermissionAccess.dhall
+
 in  { name : Text
     , on : On
     , env : Optional Env
     , concurrency : Optional Concurrency
     , defaults : Optional Defaults
+    , permissions :
+        Optional (List { mapKey : Permission, mapValue : PermissionAccess })
     , jobs : List { mapKey : Text, mapValue : Job }
     }


### PR DESCRIPTION
This PR adds `permissions` key at the workflow level.

Github reference: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-permissions-settings