### PR TITLE
Add support for merge_group

### DIFF
--- a/defaults.dhall
+++ b/defaults.dhall
@@ -3,7 +3,7 @@
       sha256:8e633f97ecc18a9abe878adf4b0b63c07d079c10d05ac96e6d0d7bb13dc7bfb0
 , On =
     ./defaults/On.dhall
-      sha256:f84a24dc87f2e8518b0b197d3ecf5f816e9e5fa7779c6841aa36ee5f5b295989
+      sha256:da5a3dff9e02909bd1386ca67e8403131351d0999962d0431ce258afffe39721
 , Step =
     ./defaults/Step.dhall
       sha256:fc31ac861cbf0231429dc5d94bf8a1f905fcdf6ec108e376c5c82b60d9ddf5c0
@@ -48,5 +48,5 @@
       sha256:e0762bf1442388cce1187fbac3e606685337f45b0e69251cfa33e513dc03c709
 , MergeGroup =
     ./defaults/events/MergeGroup.dhall
-      sha256:9adb6b3b154d4f1df647c43579e37be36ac9bbb7848cdba159863220ec52bb9f
+      sha256:61de39fb02b49bb17e966f3d22d769599874c1f98321b3accaffcbe3b9025b2b
 }

--- a/defaults.dhall
+++ b/defaults.dhall
@@ -3,7 +3,7 @@
       sha256:8e633f97ecc18a9abe878adf4b0b63c07d079c10d05ac96e6d0d7bb13dc7bfb0
 , On =
     ./defaults/On.dhall
-      sha256:74396c523fc99bf5d8334091c8e6ba3ae5ae36ba3cfb60e3c6d3a76b3d58bc25
+      sha256:f84a24dc87f2e8518b0b197d3ecf5f816e9e5fa7779c6841aa36ee5f5b295989
 , Step =
     ./defaults/Step.dhall
       sha256:fc31ac861cbf0231429dc5d94bf8a1f905fcdf6ec108e376c5c82b60d9ddf5c0
@@ -46,4 +46,7 @@
 , actions/HaskellSetup =
     ./defaults/actions/HaskellSetup.dhall
       sha256:e0762bf1442388cce1187fbac3e606685337f45b0e69251cfa33e513dc03c709
+, MergeGroup =
+    ./defaults/events/MergeGroup.dhall
+      sha256:9adb6b3b154d4f1df647c43579e37be36ac9bbb7848cdba159863220ec52bb9f
 }

--- a/defaults/On.dhall
+++ b/defaults/On.dhall
@@ -16,6 +16,8 @@ let WorkflowRun = ../types/events/WorkflowRun.dhall
 
 let Release = ../types/events/Release.dhall
 
+let MergeGroup = ../types/events/MergeGroup.dhall
+
 in  { push = None Push
     , pull_request = None PullRequest
     , pull_request_review = None PullRequestReview
@@ -25,4 +27,5 @@ in  { push = None Push
     , workflow_dispatch = None WorkflowDispatch
     , workflow_run = None WorkflowRun
     , release = None Release
+    , merge_group = None MergeGroup
     }

--- a/defaults/events/MergeGroup.dhall
+++ b/defaults/events/MergeGroup.dhall
@@ -1,0 +1,1 @@
+{ types = None (List Text) }

--- a/defaults/events/MergeGroup.dhall
+++ b/defaults/events/MergeGroup.dhall
@@ -1,1 +1,1 @@
-{ types = None (List Text) }
+{ types = None (List ../../types/events/merge_group/types.dhall) }

--- a/package.dhall
+++ b/package.dhall
@@ -1,10 +1,10 @@
     ./schemas.dhall
-      sha256:f0d0457ff42437c5697c775a3980af3f4ae38b3a489f73fe86790966d09791d5
+      sha256:e9ae07bec20bfdba4aefe69029ec287f78c3b0a6d0ebe286c255cc7b99839e1f
 /\  { steps =
         ./steps.dhall
           sha256:eba32baba369939e7fb57923fe1b60cea0d38fcc5531acf966561397e0613d41
     }
 /\  { types =
         ./types.dhall
-          sha256:bddae202d4cc1dfc603d8e8a33b62e924f6fa9bda04d36c10ba76bc27c13c86a
+          sha256:3bc9a500b78268aebc3a9894ebf86e264c69348e6a43763a3fb0fba72f5f7d0a
     }

--- a/package.dhall
+++ b/package.dhall
@@ -1,10 +1,10 @@
     ./schemas.dhall
-      sha256:47aff2c2c34ae546b942dd0e8c7e579a2fb1a6ad41fd81b621a208b5b94e383f
+      sha256:f0d0457ff42437c5697c775a3980af3f4ae38b3a489f73fe86790966d09791d5
 /\  { steps =
         ./steps.dhall
           sha256:eba32baba369939e7fb57923fe1b60cea0d38fcc5531acf966561397e0613d41
     }
 /\  { types =
         ./types.dhall
-          sha256:ec4ee6be1fe873910bdc90e29689dde6945b5520ae72e64061cb92341f69eb42
+          sha256:bddae202d4cc1dfc603d8e8a33b62e924f6fa9bda04d36c10ba76bc27c13c86a
     }

--- a/schemas.dhall
+++ b/schemas.dhall
@@ -6,7 +6,7 @@
       sha256:9ccec904643ade1050323d9ce5da865a3ad8c764a7cbc0f3c397717b1a0ece74
 , On =
     ./schemas/On.dhall
-      sha256:9c269ef17dda1545f7a6b954c195f5cc25de4066adbe8365e56c8361a7a53eb3
+      sha256:708f1dc5ea04d12378009b106eb6ef53900abb40ccfcff46f5cef0546d021e08
 , RunsOn =
     ./schemas/RunsOn.dhall
       sha256:86f5d1f0c5dc24b2033237a9194f70b14326d6bae031bd44a0630e45dd3a4b3a
@@ -21,7 +21,7 @@
       sha256:ccf7857f3b39aba24ae09b6eb2b430c96be6b3bc697ed6f0bae464e1e7bdff82
 , Workflow =
     ./schemas/Workflow.dhall
-      sha256:5f3f6f11f73fc99914094889140f9de47e1c55d9aee112ad8556e21dda5c1012
+      sha256:242eac9f78b7e51a6a634ee31ac14ae0317121e155c385b4ba216614c1db2ae1
 , Push =
     ./schemas/events/Push.dhall
       sha256:42b2efddec698fbb36321e738286478b35dfd9420ce10798659237570db55024
@@ -58,4 +58,7 @@
 , Concurrency =
     ./schemas/Concurrency.dhall
       sha256:2ed562a8c402ad394223c57857e52915ab16b94775dfc0f4d277f227b6c6d450
+, MergeGroup =
+    ./schemas/events/MergeGroup.dhall
+      sha256:53256e908fe5eb196af560db2c337b6cbc35c2eee48d6d459714554c8f777c9d
 }

--- a/schemas.dhall
+++ b/schemas.dhall
@@ -6,7 +6,7 @@
       sha256:9ccec904643ade1050323d9ce5da865a3ad8c764a7cbc0f3c397717b1a0ece74
 , On =
     ./schemas/On.dhall
-      sha256:708f1dc5ea04d12378009b106eb6ef53900abb40ccfcff46f5cef0546d021e08
+      sha256:603d2e0e29b13e0fbe123b5468c19e1ba84fdb73ce46cace6c803ac06348f408
 , RunsOn =
     ./schemas/RunsOn.dhall
       sha256:86f5d1f0c5dc24b2033237a9194f70b14326d6bae031bd44a0630e45dd3a4b3a
@@ -21,7 +21,7 @@
       sha256:ccf7857f3b39aba24ae09b6eb2b430c96be6b3bc697ed6f0bae464e1e7bdff82
 , Workflow =
     ./schemas/Workflow.dhall
-      sha256:242eac9f78b7e51a6a634ee31ac14ae0317121e155c385b4ba216614c1db2ae1
+      sha256:db179013df5c1bb345e47bddd604749c9b787f3e6913ddfcbb6174e4b4959548
 , Push =
     ./schemas/events/Push.dhall
       sha256:42b2efddec698fbb36321e738286478b35dfd9420ce10798659237570db55024
@@ -60,5 +60,5 @@
       sha256:2ed562a8c402ad394223c57857e52915ab16b94775dfc0f4d277f227b6c6d450
 , MergeGroup =
     ./schemas/events/MergeGroup.dhall
-      sha256:53256e908fe5eb196af560db2c337b6cbc35c2eee48d6d459714554c8f777c9d
+      sha256:4a3e8748d9a20ab6beec8bd7dcca67b465e600563c5dbfca4cd3d464c9f69dcb
 }

--- a/schemas/events/MergeGroup.dhall
+++ b/schemas/events/MergeGroup.dhall
@@ -1,0 +1,3 @@
+{ Type = ../../types/events/MergeGroup.dhall
+, default = ../../defaults/events/MergeGroup.dhall
+}

--- a/types.dhall
+++ b/types.dhall
@@ -12,7 +12,7 @@
       sha256:060bf27380c527f136c2c86ba1cf1f7cab6ad3dd339e655db0873cc8068b7b9d
 , On =
     ./types/On.dhall
-      sha256:488cf8f32c7043bea7d45048a490c2c1508e8d7a92fc5fcef73c1d08f7a7bf22
+      sha256:32bdaae69fe18855179af3f880bae8540d61b2ff154efe2fc9b2fe24a8fe209b
 , Step =
     ./types/Step.dhall
       sha256:c2efe65fd3b819521612000af9ebee52e7a74cce4c37de891dcdc7d6c25169fa
@@ -27,7 +27,7 @@
       sha256:c957b80c6a0d53dce7bf05921c1983797b5d52958ded76244cd94ae80deb94e5
 , Workflow =
     ./types/Workflow.dhall
-      sha256:cc358fbe54c43cf9e900e5eb27a8ef3eba5534f727002e0ef1ef9d8d24af7701
+      sha256:1b3082acb962616d1534dea30542fecd371eea07acd550f854f449b49bded94c
 , Push =
     ./types/events/Push.dhall
       sha256:5147b1dd6eca94aae5d217b979cac20ba64b7ec160488dd917f171cae451b135
@@ -75,5 +75,8 @@
       sha256:3cfef5c383d40623d0766715715c881583623bf6e11a0ad0b9946d8eaeffa6c5
 , MergeGroup =
     ./types/events/MergeGroup.dhall
-      sha256:f7a1d37a7fa9ce33f736813d132503dcf9c46a3fc72c7327c07d799af9f6ea63
+      sha256:6932501dad0293756c78e48f64ae6b5549d373f7a178c26e300b69341de81fd6
+, MergeGroup/types =
+    ./types/events/merge_group/types.dhall
+      sha256:395eaa0f656449d1bca8c63e6631a999c47deab93659ad1a2b4999d415f8d0ac
 }

--- a/types.dhall
+++ b/types.dhall
@@ -12,7 +12,7 @@
       sha256:060bf27380c527f136c2c86ba1cf1f7cab6ad3dd339e655db0873cc8068b7b9d
 , On =
     ./types/On.dhall
-      sha256:1b9cee24cb15eeef7d0d9eb61f9894898421adc5d68cad06c3445032da48e102
+      sha256:488cf8f32c7043bea7d45048a490c2c1508e8d7a92fc5fcef73c1d08f7a7bf22
 , Step =
     ./types/Step.dhall
       sha256:c2efe65fd3b819521612000af9ebee52e7a74cce4c37de891dcdc7d6c25169fa
@@ -27,7 +27,7 @@
       sha256:c957b80c6a0d53dce7bf05921c1983797b5d52958ded76244cd94ae80deb94e5
 , Workflow =
     ./types/Workflow.dhall
-      sha256:b75d2dcd4b2cf6be5149a3913006213eee1e50769f103eb34430d43162676b1a
+      sha256:cc358fbe54c43cf9e900e5eb27a8ef3eba5534f727002e0ef1ef9d8d24af7701
 , Push =
     ./types/events/Push.dhall
       sha256:5147b1dd6eca94aae5d217b979cac20ba64b7ec160488dd917f171cae451b135
@@ -73,4 +73,7 @@
 , actions/HaskellSetup =
     ./types/actions/HaskellSetup.dhall
       sha256:3cfef5c383d40623d0766715715c881583623bf6e11a0ad0b9946d8eaeffa6c5
+, MergeGroup =
+    ./types/events/MergeGroup.dhall
+      sha256:f7a1d37a7fa9ce33f736813d132503dcf9c46a3fc72c7327c07d799af9f6ea63
 }

--- a/types/On.dhall
+++ b/types/On.dhall
@@ -16,6 +16,8 @@ let WorkflowRun = ./events/WorkflowRun.dhall
 
 let Release = ./events/Release.dhall
 
+let MergeGroup = ./events/MergeGroup.dhall
+
 in  { push : Optional Push
     , pull_request : Optional PullRequest
     , pull_request_review : Optional PullRequestReview
@@ -25,4 +27,5 @@ in  { push : Optional Push
     , workflow_dispatch : Optional WorkflowDispatch
     , workflow_run : Optional WorkflowRun
     , release : Optional Release
+    , merge_group : Optional MergeGroup
     }

--- a/types/events/MergeGroup.dhall
+++ b/types/events/MergeGroup.dhall
@@ -1,0 +1,1 @@
+{ types : Optional (List Text) }

--- a/types/events/MergeGroup.dhall
+++ b/types/events/MergeGroup.dhall
@@ -1,1 +1,1 @@
-{ types : Optional (List Text) }
+{ types : Optional (List ./merge_group/types.dhall) }

--- a/types/events/merge_group/types.dhall
+++ b/types/events/merge_group/types.dhall
@@ -1,0 +1,1 @@
+< checks_requested >


### PR DESCRIPTION
GitHub has recently added [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) as a beta feature. To trigger a workflow when a pull request is added to a merge queue, one must add `merge_group` to the `on` section as shown in [this example](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions).

This PR proposes adding support for `merge_group`. Documentation about the event can be found here: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group