### PR TITLE
Add support for pull_request_target

### DIFF
--- a/defaults.dhall
+++ b/defaults.dhall
@@ -3,7 +3,7 @@
       sha256:8e633f97ecc18a9abe878adf4b0b63c07d079c10d05ac96e6d0d7bb13dc7bfb0
 , On =
     ./defaults/On.dhall
-      sha256:da5a3dff9e02909bd1386ca67e8403131351d0999962d0431ce258afffe39721
+      sha256:5237c0c8cc44b92d9e6cb19e858f8000e77cc8eedecb94dec9644ca44162b125
 , Step =
     ./defaults/Step.dhall
       sha256:fc31ac861cbf0231429dc5d94bf8a1f905fcdf6ec108e376c5c82b60d9ddf5c0

--- a/defaults/On.dhall
+++ b/defaults/On.dhall
@@ -18,9 +18,12 @@ let Release = ../types/events/Release.dhall
 
 let MergeGroup = ../types/events/MergeGroup.dhall
 
+let PullRequestTarget = ../types/events/PullRequestTarget.dhall
+
 in  { push = None Push
     , pull_request = None PullRequest
     , pull_request_review = None PullRequestReview
+    , pull_request_target = None PullRequestTarget
     , delete = None Delete
     , schedule = None (List Schedule)
     , repository_dispatch = None RepositoryDispatch

--- a/defaults/events/PullRequestTarget.dhall
+++ b/defaults/events/PullRequestTarget.dhall
@@ -1,0 +1,6 @@
+{ types = None ../../types/events/pull_request_target/types.dhall
+, branches = None (List Text)
+, branches-ignore = None (List Text)
+, paths = None (List Text)
+, paths-ignore = None (List Text)
+}

--- a/package.dhall
+++ b/package.dhall
@@ -1,10 +1,10 @@
     ./schemas.dhall
-      sha256:e9ae07bec20bfdba4aefe69029ec287f78c3b0a6d0ebe286c255cc7b99839e1f
+      sha256:57ddd0374e064cd1360c45ee0271685c8b95fb108e1b1ab3913cc5f51ebb8824
 /\  { steps =
         ./steps.dhall
           sha256:eba32baba369939e7fb57923fe1b60cea0d38fcc5531acf966561397e0613d41
     }
 /\  { types =
         ./types.dhall
-          sha256:3bc9a500b78268aebc3a9894ebf86e264c69348e6a43763a3fb0fba72f5f7d0a
+          sha256:31a40b214d2d39dea2e3f010ca883809be0124b22e1f31ee40532e660732dda5
     }

--- a/schemas.dhall
+++ b/schemas.dhall
@@ -6,7 +6,7 @@
       sha256:9ccec904643ade1050323d9ce5da865a3ad8c764a7cbc0f3c397717b1a0ece74
 , On =
     ./schemas/On.dhall
-      sha256:603d2e0e29b13e0fbe123b5468c19e1ba84fdb73ce46cace6c803ac06348f408
+      sha256:628e8c2a25e427a771d7412d0edf38a59ad5662958b8909bfe145c9db02fb344
 , RunsOn =
     ./schemas/RunsOn.dhall
       sha256:86f5d1f0c5dc24b2033237a9194f70b14326d6bae031bd44a0630e45dd3a4b3a
@@ -21,7 +21,7 @@
       sha256:ccf7857f3b39aba24ae09b6eb2b430c96be6b3bc697ed6f0bae464e1e7bdff82
 , Workflow =
     ./schemas/Workflow.dhall
-      sha256:db179013df5c1bb345e47bddd604749c9b787f3e6913ddfcbb6174e4b4959548
+      sha256:820224d0acdc7719c3eec45554365548a6af462016567810b6410cc63df94208
 , Push =
     ./schemas/events/Push.dhall
       sha256:42b2efddec698fbb36321e738286478b35dfd9420ce10798659237570db55024
@@ -31,6 +31,9 @@
 , PullRequestReview =
     ./schemas/events/PullRequestReview.dhall
       sha256:53256e908fe5eb196af560db2c337b6cbc35c2eee48d6d459714554c8f777c9d
+, PullRequestTarget =
+    ./schemas/events/PullRequestTarget.dhall
+      sha256:6ae100205bbbf6a3d093ee8fa1cf03b19576846d38249a71c6f4402d0a201c49
 , Delete =
     ./schemas/events/Delete.dhall
       sha256:81a1bf11fb9dc588941bd83400ed571298585a700a53e858456806f7ea3b8ce2

--- a/schemas/events/PullRequestTarget.dhall
+++ b/schemas/events/PullRequestTarget.dhall
@@ -1,0 +1,3 @@
+{ Type = ../../types/events/PullRequestTarget.dhall
+, default = ../../defaults/events/PullRequestTarget.dhall
+}

--- a/types.dhall
+++ b/types.dhall
@@ -12,7 +12,7 @@
       sha256:060bf27380c527f136c2c86ba1cf1f7cab6ad3dd339e655db0873cc8068b7b9d
 , On =
     ./types/On.dhall
-      sha256:32bdaae69fe18855179af3f880bae8540d61b2ff154efe2fc9b2fe24a8fe209b
+      sha256:92d4b82ec461d4d65e0e0d70facad957d91fb154483f2080c8dbf3b42cb71557
 , Step =
     ./types/Step.dhall
       sha256:c2efe65fd3b819521612000af9ebee52e7a74cce4c37de891dcdc7d6c25169fa
@@ -27,7 +27,7 @@
       sha256:c957b80c6a0d53dce7bf05921c1983797b5d52958ded76244cd94ae80deb94e5
 , Workflow =
     ./types/Workflow.dhall
-      sha256:1b3082acb962616d1534dea30542fecd371eea07acd550f854f449b49bded94c
+      sha256:616bf6371588b75df451e4cecc2ca11cf886e83b46f975b3f22a9b96b31acca7
 , Push =
     ./types/events/Push.dhall
       sha256:5147b1dd6eca94aae5d217b979cac20ba64b7ec160488dd917f171cae451b135
@@ -37,6 +37,12 @@
 , PullRequestReview =
     ./types/events/PullRequestReview.dhall
       sha256:f7a1d37a7fa9ce33f736813d132503dcf9c46a3fc72c7327c07d799af9f6ea63
+, PullRequestTarget =
+    ./types/events/PullRequestTarget.dhall
+      sha256:9fdd8e4bc6e46d0b4989ee2d6f875d07d96eca41e1ebf3ca4799e59d90ea9fdb
+, PullRequestTarget/types =
+    ./types/events/pull_request_target/types.dhall
+      sha256:1bd793b250a4f223653e63c8cf01af28cc211f62b31e7f41d0817c6ca6caaa0a
 , Delete =
     ./types/events/Delete.dhall
       sha256:0912602a19e01dcff30f351958d2d9b69519c9be61b57b1b32a2a569bf8bf5f9

--- a/types/On.dhall
+++ b/types/On.dhall
@@ -18,9 +18,12 @@ let Release = ./events/Release.dhall
 
 let MergeGroup = ./events/MergeGroup.dhall
 
+let PullRequestTarget = ./events/PullRequestTarget.dhall
+
 in  { push : Optional Push
     , pull_request : Optional PullRequest
     , pull_request_review : Optional PullRequestReview
+    , pull_request_target : Optional PullRequestTarget
     , delete : Optional Delete
     , schedule : Optional (List Schedule)
     , repository_dispatch : Optional RepositoryDispatch

--- a/types/events/PullRequestTarget.dhall
+++ b/types/events/PullRequestTarget.dhall
@@ -1,0 +1,6 @@
+{ types : Optional ./pull_request_target/types.dhall
+, branches : Optional (List Text)
+, branches-ignore : Optional (List Text)
+, paths : Optional (List Text)
+, paths-ignore : Optional (List Text)
+}

--- a/types/events/pull_request_target/types.dhall
+++ b/types/events/pull_request_target/types.dhall
@@ -1,0 +1,1 @@
+< assigned | opened | synchronize | reopened >


### PR DESCRIPTION
Hi @regadas 

This PR proposes adding support for [the `pull_request_target` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target). I read through the event docs and [the workflow syntax docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onevent_nametypes) and I beleive the `PullRequestTarget` type has all the necessary fields with appropriate types.