### PR TITLE
feat: Add support for jobs.<job_id>.continue-on-error

### DIFF
--- a/defaults.dhall
+++ b/defaults.dhall
@@ -1,6 +1,6 @@
 { Job =
     ./defaults/Job.dhall
-      sha256:8e633f97ecc18a9abe878adf4b0b63c07d079c10d05ac96e6d0d7bb13dc7bfb0
+      sha256:0181093d1c7e4727d61088f8eea1e3c76646874d5797a38a8d5c1a209b4c707d
 , On =
     ./defaults/On.dhall
       sha256:5237c0c8cc44b92d9e6cb19e858f8000e77cc8eedecb94dec9644ca44162b125

--- a/defaults/Job.dhall
+++ b/defaults/Job.dhall
@@ -16,8 +16,11 @@ let Permission = ../types/Permission.dhall
 
 let PermissionAccess = ../types/PermissionAccess.dhall
 
+let ContinueOnError = ../types/ContinueOnError.dhall
+
 in  { name = None Text
     , needs = None (List Text)
+    , continue-on-error = None ContinueOnError
     , strategy = None Strategy
     , environment = None JobEnv
     , outputs = None (List { mapKey : Text, mapValue : Text })

--- a/package.dhall
+++ b/package.dhall
@@ -1,10 +1,10 @@
     ./schemas.dhall
-      sha256:57ddd0374e064cd1360c45ee0271685c8b95fb108e1b1ab3913cc5f51ebb8824
+      sha256:8e4a474e782697628779ebd5e0a39564de169a84a55b162a368a2abd70dd4c63
 /\  { steps =
         ./steps.dhall
           sha256:eba32baba369939e7fb57923fe1b60cea0d38fcc5531acf966561397e0613d41
     }
 /\  { types =
         ./types.dhall
-          sha256:31a40b214d2d39dea2e3f010ca883809be0124b22e1f31ee40532e660732dda5
+          sha256:0d094fe9dae5041b1d9747a6460e2d17d9788f6f882ae03a08277b80b1e14e5c
     }

--- a/schemas.dhall
+++ b/schemas.dhall
@@ -1,6 +1,6 @@
 { Job =
     ./schemas/Job.dhall
-      sha256:eff41a57bfc5454ec632236ae87a9b08b95e63d106502f926d243b6fdaee3bef
+      sha256:737288e197103c8d0a267bc31f4939d2aa8e7d1feb849836e9aac8986f39a9f1
 , JobEnv =
     ./schemas/JobEnv.dhall
       sha256:9ccec904643ade1050323d9ce5da865a3ad8c764a7cbc0f3c397717b1a0ece74
@@ -21,7 +21,7 @@
       sha256:ccf7857f3b39aba24ae09b6eb2b430c96be6b3bc697ed6f0bae464e1e7bdff82
 , Workflow =
     ./schemas/Workflow.dhall
-      sha256:820224d0acdc7719c3eec45554365548a6af462016567810b6410cc63df94208
+      sha256:7078d37e4c867fb2875fedf80fb20df7a2c7c42952dd11440eb7fc39f8ca3225
 , Push =
     ./schemas/events/Push.dhall
       sha256:42b2efddec698fbb36321e738286478b35dfd9420ce10798659237570db55024

--- a/types.dhall
+++ b/types.dhall
@@ -1,6 +1,6 @@
 { Job =
     ./types/Job.dhall
-      sha256:c96169cb1e2a65e6d6d9f11fc29589d306abb626aaeda34355c42bda5de37af1
+      sha256:d84571c575ce2f1d56dbddfa73494856296a079d341a3d05baa7d20ab39ce3fc
 , JobEnv =
     ./types/JobEnv.dhall
       sha256:521e86d74ae30cec88804eb9fa8014510297c9cf6b4b412d1576df31ed72dc6f
@@ -27,7 +27,7 @@
       sha256:c957b80c6a0d53dce7bf05921c1983797b5d52958ded76244cd94ae80deb94e5
 , Workflow =
     ./types/Workflow.dhall
-      sha256:616bf6371588b75df451e4cecc2ca11cf886e83b46f975b3f22a9b96b31acca7
+      sha256:206cdf388ba8e3b832674d18a955ad0a6c509e65a4674b9e4aeb4609c3f260ae
 , Push =
     ./types/events/Push.dhall
       sha256:5147b1dd6eca94aae5d217b979cac20ba64b7ec160488dd917f171cae451b135
@@ -85,4 +85,7 @@
 , MergeGroup/types =
     ./types/events/merge_group/types.dhall
       sha256:395eaa0f656449d1bca8c63e6631a999c47deab93659ad1a2b4999d415f8d0ac
+, ContinueOnError =
+    ./types/ContinueOnError.dhall
+      sha256:83ad8f8eea100277b6658ac27c590d6ee43df14e4d1fc49a55c691e1033fd3e9
 }

--- a/types/ContinueOnError.dhall
+++ b/types/ContinueOnError.dhall
@@ -1,0 +1,1 @@
+< Expression : Text | Boolean : Bool >

--- a/types/Job.dhall
+++ b/types/Job.dhall
@@ -20,8 +20,11 @@ let Permission = ./Permission.dhall
 
 let PermissionAccess = ./PermissionAccess.dhall
 
+let ContinueOnError = ./ContinueOnError.dhall
+
 in  { name : Optional Text
     , needs : Optional (List Text)
+    , continue-on-error : Optional ContinueOnError
     , runs-on : RunsOn
     , environment : Optional JobEnv
     , strategy : Optional Strategy


### PR DESCRIPTION
This PR proposes adding support for  `jobs.<job_id>.continue-on-error`.

The docs show an example where `continue-on-error` is [set to an expression](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-preventing-a-specific-failing-matrix-job-from-failing-a-workflow-run). As such, I used a union to support `Text` and `Bool`.

For my needs, I use `continue-on-error` like so...

```dhall
continue-on-error = Some (GithubActions.types.ContinueOnError.Boolean True)
````