### PR TITLE
Update the `actions/cache` step to v4

### DIFF
--- a/examples/out/scala.yaml
+++ b/examples/out/scala.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v2"
       - name: "~/.sbt\n\"~/.cache/coursier\"\n cache"
-        uses: "actions/cache@v3"
+        uses: "actions/cache@v4"
         with:
           key: "${{ runner.os }}-sbt-${{ hashFiles('build.sbt', 'project/plugins.sbt', 'project/build.properties', 'project/Dependencies.scala') }}"
           path: |
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: "actions/checkout@v2"
       - name: "~/.sbt\n\"~/.cache/coursier\"\n cache"
-        uses: "actions/cache@v3"
+        uses: "actions/cache@v4"
         with:
           key: "${{ runner.os }}-sbt-${{ hashFiles('build.sbt', 'project/plugins.sbt', 'project/build.properties', 'project/Dependencies.scala') }}"
           path: |

--- a/steps.dhall
+++ b/steps.dhall
@@ -9,7 +9,7 @@
       sha256:8a22d29eea007b2df0c3467dc732b835e46f3daccefba38312d4b4446c50b006
 , actions/cache =
     ./steps/actions/cache.dhall
-      sha256:8828d57d24a29354d6be9ca28db540224f89aec12cda593abe1580729e10ebc4
+      sha256:b6d6702a9faa91b3b64f9ac7e84b1f8706a460dd02fcf2e47cbbedb9053e6e96
 , actions/helloWorld =
     ./steps/actions/helloWorld.dhall
       sha256:69bc163d0b30165fb1792c23871a0ad6fade1095517f6b3fa3b834a615f3d2fc

--- a/steps/actions/cache.dhall
+++ b/steps/actions/cache.dhall
@@ -22,7 +22,7 @@ in  λ(args : { path : Text, key : Text, hashFiles : List Text }) →
 
       in  Step::{
           , name = Some "${args.path} cache"
-          , uses = Some "actions/cache@v3"
+          , uses = Some "actions/cache@v4"
           , `with` = Some
               ( toMap
                   { path = args.path


### PR DESCRIPTION
```
Node.js 16 actions are deprecated. Please update the following actions
to use Node.js 20: actions/cache@v3. For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```