### PR TITLE
Add more runners in runs-on. Also add Optional Input type

### DIFF
--- a/defaults.dhall
+++ b/defaults.dhall
@@ -3,7 +3,7 @@
       sha256:0b6c2901d8f26ad1ca0df889ac09eb55534473c92166097a5e8b717b90358cc8
 , On =
     ./defaults/On.dhall
-      sha256:048526efc174160bdaf8db6b254697e01d36f6d2411e9cd5da83647e751b7a25
+      sha256:863bd06803849476a3c097ea67465867c2ca232bbe8f8250fb151278d2e3cebd
 , Step =
     ./defaults/Step.dhall
       sha256:fc31ac861cbf0231429dc5d94bf8a1f905fcdf6ec108e376c5c82b60d9ddf5c0
@@ -42,10 +42,10 @@
       sha256:9adb6b3b154d4f1df647c43579e37be36ac9bbb7848cdba159863220ec52bb9f
 , WorkflowCall =
     ./defaults/events/WorkflowCall.dhall
-      sha256:8f27a30a5568ea13c7140f149d4c0087d4dad17baa4deaba1580f1dac6f983ed
+      sha256:3915943138e887c98ee7a05bd19461dc22ca892614f14e4fbac7c7ba8c8eb97e
 , WorkflowDispatch =
     ./defaults/events/WorkflowDispatch.dhall
-      sha256:2133dc321eb5b06cd0c9ffb6cd412fa1dfd7e20c4341fecbff2b17ce29119958
+      sha256:a716e8cb55dc8f5eb7ac0ad7dd5001c8294f18af73027fcc32668793be084d29
 , WorkflowRun =
     ./defaults/events/WorkflowRun.dhall
       sha256:1c1282b9bd39e056cf38d17a3f5e235e80af8cd98f9163addd508d0a792a6c51

--- a/defaults.dhall
+++ b/defaults.dhall
@@ -30,7 +30,7 @@
       sha256:9bb9dcb5bf6f795291686f59383bcd01c8e79b87fc3fb63351d46dea100ac51b
 , Input =
     ./defaults/Input.dhall
-      sha256:047d951f9f951543458f7dd6ceffb5d53585fe2d59ff2a1616e8f4e130615f1a
+      sha256:df12c8ed01a5352e459a85682b0f85dbf87c9b77536c91ac351dc4c2b53b6fca
 , Output =
     ./defaults/Output.dhall
       sha256:15e5b80617e8fe293b16c2698712ac767dc1690ff74f28b174539cc664caa3dd

--- a/defaults/Input.dhall
+++ b/defaults/Input.dhall
@@ -1,1 +1,1 @@
-{ description = None Text, default = None Text, required = False }
+{ description = None Text, default = None Text, required = False, type = None < boolean | choice | number | environment | string > }

--- a/defaults/Input.dhall
+++ b/defaults/Input.dhall
@@ -1,1 +1,1 @@
-{ description = None Text, default = None Text, required = False, type = None < boolean | choice | number | environment | string > }
+{ description = None Text, default = None Text, required = False, type = None ../types/InputType.dhall }

--- a/package.dhall
+++ b/package.dhall
@@ -1,10 +1,10 @@
     ./schemas.dhall
-      sha256:c72c7f253a6a2d8dd25ff24bbaf4f746f3fe68c205e97d7673bf0d9f9aaa08c8
+      sha256:6d18d53d0f62bc665f6bd1bc22468bcb7dd6c42cd4d83b97c7f1bc23b062566b
 /\  { steps =
         ./steps.dhall
           sha256:ba64a8b88c72d500a8536958ca6be764a01b76aa52f02376a789bd93d0f797c0
     }
 /\  { types =
         ./types.dhall
-          sha256:60dbb08df69e8849dc944295c00c4aa2736af78e87571529cc644a7d33ef2578
+          sha256:19ac8dc3e24c0b74db5004ed7df709f6de746477d297efcd3bedc7cb7d044777
     }

--- a/package.dhall
+++ b/package.dhall
@@ -1,10 +1,10 @@
     ./schemas.dhall
-      sha256:6d18d53d0f62bc665f6bd1bc22468bcb7dd6c42cd4d83b97c7f1bc23b062566b
+      sha256:e846d70b8b0632effc9d3636b980134d88eabdb64825b0929091fbe6d78db314
 /\  { steps =
         ./steps.dhall
           sha256:ba64a8b88c72d500a8536958ca6be764a01b76aa52f02376a789bd93d0f797c0
     }
 /\  { types =
         ./types.dhall
-          sha256:19ac8dc3e24c0b74db5004ed7df709f6de746477d297efcd3bedc7cb7d044777
+          sha256:4a1d52641e870be02dd236dc745e46df472d4dbf44bd93bc3e98e72eb10b315a
     }

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
     ./schemas.dhall
-      sha256:e846d70b8b0632effc9d3636b980134d88eabdb64825b0929091fbe6d78db314
+      sha256:a83606c62b5bcb1d807446d713a6cb458e5fd3d1f3517cdd212228cb2971ee18
 /\  { steps =
         ./steps.dhall
           sha256:ba64a8b88c72d500a8536958ca6be764a01b76aa52f02376a789bd93d0f797c0

--- a/schemas.dhall
+++ b/schemas.dhall
@@ -43,6 +43,9 @@
 , Input =
     ./schemas/Input.dhall
       sha256:e7d67b6e4cc8f4f306cbcf63726aaa98857e5f82b1f5144c9bc20e6792d4c327
+, InputType =
+    ./schemas/InputType.dhall
+      sha256:1a3f2617073a99318a669399297294488d9a6a69100ca9607c44609a9a62343e
 , Output =
     ./schemas/Output.dhall
       sha256:f01b31455186c9ecf937b48023d9408a7d5bf5db3fc4964b6060a43e1c4dabe8

--- a/schemas.dhall
+++ b/schemas.dhall
@@ -1,15 +1,15 @@
 { Job =
     ./schemas/Job.dhall
-      sha256:e96bc1c8a9f662d348bd72a2613449cade5e00ab3132de531ce04ce859faba48
+      sha256:2610292fbd89a567160f94d612761394e7cf5ab527b89cfa1f9de41a6a9af1fc
 , JobEnv =
     ./schemas/JobEnv.dhall
       sha256:9ccec904643ade1050323d9ce5da865a3ad8c764a7cbc0f3c397717b1a0ece74
 , On =
     ./schemas/On.dhall
-      sha256:b1f216f4eba7db0981c3b611ca704a6ddda23ce53643cad26ddd96f0f8444e6b
+      sha256:d603159cb9fee79b830cb1c1bb58fb247a1984795a4a01a1ee26baa8dc531e8a
 , RunsOn =
     ./schemas/RunsOn.dhall
-      sha256:86f5d1f0c5dc24b2033237a9194f70b14326d6bae031bd44a0630e45dd3a4b3a
+      sha256:8bdd3fbcd62c0e10dbd78a71ca155c712df5687f2e93713c7e6248ffe9739f6d
 , Step =
     ./schemas/Step.dhall
       sha256:7e0c2877e2ee3d57de46c1bf631d36f3d0ff636f73514233dbed3f100d2530ce
@@ -21,7 +21,7 @@
       sha256:ccf7857f3b39aba24ae09b6eb2b430c96be6b3bc697ed6f0bae464e1e7bdff82
 , Workflow =
     ./schemas/Workflow.dhall
-      sha256:b72583f0346169b1c24f73412f29b193e282a5e74b42e69b8ad73f2eebf3fe57
+      sha256:7b9fde125f72f9db6fdd98399ff4e8431376861a33bb3c203e5b33da0f48fd22
 , Push =
     ./schemas/events/Push.dhall
       sha256:42b2efddec698fbb36321e738286478b35dfd9420ce10798659237570db55024
@@ -42,7 +42,7 @@
       sha256:03caaa6deeed4018094f9a77b2db6f49c28ca75874c44e2256e8147894c30746
 , Input =
     ./schemas/Input.dhall
-      sha256:f15ab36ac38cb32a757173088ec95050e3cb3fe8765bd1d4cc49851cec7877d8
+      sha256:f1a8de2b17261b4665f264703c7e984d0a8da6a9202b402aeb84dc281e8f98e4
 , Output =
     ./schemas/Output.dhall
       sha256:f01b31455186c9ecf937b48023d9408a7d5bf5db3fc4964b6060a43e1c4dabe8
@@ -54,10 +54,10 @@
       sha256:53256e908fe5eb196af560db2c337b6cbc35c2eee48d6d459714554c8f777c9d
 , WorkflowCall =
     ./schemas/events/WorkflowCall.dhall
-      sha256:cafacd2c02714f9e00ad420661a13bf80bab0921f99601ff38338e6eaefc1ad9
+      sha256:0d426c3ad8d247dff28e40f2582da1a84b524e9d30d846cc4b29a8d506f4a800
 , WorkflowDispatch =
     ./schemas/events/WorkflowDispatch.dhall
-      sha256:f3243d9aaa461034e9844d51fb4e2c646a956ea3df2d1f12ae31e16ee29b1a55
+      sha256:46a12434dc48946da6d5debfb5806991198c3d091f80fd3e2690838380602712
 , WorkflowRun =
     ./schemas/events/WorkflowRun.dhall
       sha256:e9b84d6d0609aca151aa330fd150bc6a9fde057235dec7ca594d6369c9165bb1

--- a/schemas.dhall
+++ b/schemas.dhall
@@ -42,7 +42,7 @@
       sha256:03caaa6deeed4018094f9a77b2db6f49c28ca75874c44e2256e8147894c30746
 , Input =
     ./schemas/Input.dhall
-      sha256:f1a8de2b17261b4665f264703c7e984d0a8da6a9202b402aeb84dc281e8f98e4
+      sha256:e7d67b6e4cc8f4f306cbcf63726aaa98857e5f82b1f5144c9bc20e6792d4c327
 , Output =
     ./schemas/Output.dhall
       sha256:f01b31455186c9ecf937b48023d9408a7d5bf5db3fc4964b6060a43e1c4dabe8

--- a/schemas/InputType.dhall
+++ b/schemas/InputType.dhall
@@ -1,0 +1,1 @@
+{ Type = ../types/InputType.dhall }

--- a/types.dhall
+++ b/types.dhall
@@ -64,6 +64,9 @@
 , Input =
     ./types/Input.dhall
       sha256:03df056682410688325a8cca24cd3c167b2db0a1b87596450de5638ffaa68b2c
+, InputType =
+    ./types/InputType.dhall
+      sha256:abf2c8ba31afdcd4a7ffc485968d38395dc2e36fbd8d748a6889b532fdc6209f
 , Output =
     ./types/Output.dhall
       sha256:4c7baccef8bd151904013c18b9cb539944019e8d85c2cb53c89d01988cde052c

--- a/types.dhall
+++ b/types.dhall
@@ -1,6 +1,6 @@
 { Job =
     ./types/Job.dhall
-      sha256:12eac8e789ab64e3c784beee10bda21fcbdb011ad45874276bb088fd42ee0577
+      sha256:188b0ff021b3655e231fd815ec318f7c4bbb09c80e21476279500de49ab41945
 , JobEnv =
     ./types/JobEnv.dhall
       sha256:521e86d74ae30cec88804eb9fa8014510297c9cf6b4b412d1576df31ed72dc6f
@@ -12,13 +12,13 @@
       sha256:060bf27380c527f136c2c86ba1cf1f7cab6ad3dd339e655db0873cc8068b7b9d
 , On =
     ./types/On.dhall
-      sha256:aa5f44a98010892489d1e6b73e1dd0116d5c9c7880c0ccebd0678f609fb671e9
+      sha256:72fbd13d4345c106ea4dcaea1e90886f87132165c9203ffcf4a230c216ddb754
 , Step =
     ./types/Step.dhall
       sha256:c2efe65fd3b819521612000af9ebee52e7a74cce4c37de891dcdc7d6c25169fa
 , RunsOn =
     ./types/RunsOn.dhall
-      sha256:9efc5b4e1cc4ce2f06aa59c77ae4f9fb47287d79b65c8469dbfa375af9eb21e8
+      sha256:17864110f3cc91183c178f8218967c500f3493391e5327740dd1f19c74eb6ee2
 , Env =
     ./types/Env.dhall
       sha256:e73a2ec07449acffe1a4ba9cd261b845a8beb8f81fbc1415575639e99da668e6
@@ -27,7 +27,7 @@
       sha256:c957b80c6a0d53dce7bf05921c1983797b5d52958ded76244cd94ae80deb94e5
 , Workflow =
     ./types/Workflow.dhall
-      sha256:8c61b0e08c560608a0f97ed1d93ac351df1cd9b8ce64e23d2d647a227de79ba7
+      sha256:8b9199905c1a9a900e2678c36018d93815c2339db5c5f65d54e9873f468c48f9
 , Push =
     ./types/events/Push.dhall
       sha256:5147b1dd6eca94aae5d217b979cac20ba64b7ec160488dd917f171cae451b135
@@ -63,7 +63,7 @@
       sha256:eb91edc996fadffb9cac1b67a4da220eed6bf54e96f7b8accbb613462e402537
 , Input =
     ./types/Input.dhall
-      sha256:4723eaffcfb407926dbda34ad46b0e4159885063a24aa26351fd86417a150c4a
+      sha256:03df056682410688325a8cca24cd3c167b2db0a1b87596450de5638ffaa68b2c
 , Output =
     ./types/Output.dhall
       sha256:4c7baccef8bd151904013c18b9cb539944019e8d85c2cb53c89d01988cde052c
@@ -75,10 +75,10 @@
       sha256:f7a1d37a7fa9ce33f736813d132503dcf9c46a3fc72c7327c07d799af9f6ea63
 , WorkflowCall =
     ./types/events/WorkflowCall.dhall
-      sha256:8fa0371a0e0618210d7ac34213b516c726194410055879eafc8f8e2523ba6a8a
+      sha256:08e5e74916cbdd4bb28988b144ecec79ece5d56336d84e458fc9e2985b0ba681
 , WorkflowDispatch =
     ./types/events/WorkflowDispatch.dhall
-      sha256:6a5553c84dd7397eb24b3f94326d9ae9cfae04ace8fa55606319ee312d023ef8
+      sha256:7c424307eed6fd275ccba117a66d3850b71ea6d41791d0544d1fad6f2ac5025a
 , WorkflowRun =
     ./types/events/WorkflowRun.dhall
       sha256:63a3c3130a74d1af7e25a73b55ab719cda4a26ba0bfdee72214be7e43d23c46a

--- a/types/Input.dhall
+++ b/types/Input.dhall
@@ -1,1 +1,1 @@
-{ description : Optional Text, required : Bool, default : Optional Text, type : Optional < boolean | choice | number | environment | string > }
+{ description : Optional Text, required : Bool, default : Optional Text, type : Optional ./InputType.dhall }

--- a/types/Input.dhall
+++ b/types/Input.dhall
@@ -1,1 +1,1 @@
-{ description : Optional Text, required : Bool, default : Optional Text }
+{ description : Optional Text, required : Bool, default : Optional Text, type : Optional < boolean | choice | number | environment | string > }

--- a/types/InputType.dhall
+++ b/types/InputType.dhall
@@ -1,0 +1,6 @@
+< boolean
+| choice
+| number
+| environment
+| string
+>

--- a/types/RunsOn.dhall
+++ b/types/RunsOn.dhall
@@ -1,10 +1,16 @@
 < windows-latest
+| windows-2022
 | windows-2019
 | ubuntu-latest
+| `ubuntu-24.04`
+| `ubuntu-22.04`
 | `ubuntu-20.04`
 | `ubuntu-18.04`
 | `ubuntu-16.04`
 | macos-latest
+| macos-14
+| macos-13
+| macos-12
 | `macos-10.05`
 | self-hosted
 | custom : List Text


### PR DESCRIPTION
Updated the runner list to [use latest list from Github](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).

Also add Optional `inputs.<input id>.type` for workflow inputs. Reference: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputsinput_idtype